### PR TITLE
Refactor/test and game

### DIFF
--- a/lib/column.rb
+++ b/lib/column.rb
@@ -1,27 +1,27 @@
 class Column
-  attr_reader :rows, :count #can remove from reader
+  attr_reader :rows, :count
 
   def initialize
     @rows = []
-    @count = 5   #
+    @count = 5 
     generate_rows
   end
 
   def generate_rows
     6.times do
-      @rows << Row.new
+      rows << Row.new
     end
-    @rows[5].toggle_playable
+    rows[5].toggle_playable
   end
 
   def play_piece(player)
-    if @count > 0 && @rows[count].playable == true
-      @rows[count].toggle_player(player)         
-      @rows[count - 1].toggle_playable
+    if count > 0 && rows[count].playable == true
+      rows[count].toggle_player(player)         
+      rows[count - 1].toggle_playable
       @count -= 1
-    elsif @count == 0 && @rows[count].playable == true
-      @rows[count].toggle_player(player)
-    else puts "That is an invalid move." #evaluate later where best location is for this 
+    elsif count == 0 && rows[count].playable == true
+      rows[count].toggle_player(player)
+    else :invalid_move 
     end
   end
 end

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -15,7 +15,9 @@ class Game
   end
 
   def user_input
-    gets.chomp.upcase
+    input = gets.chomp
+    abort if input.upcase == "QUIT"
+    input
   end
 
   def set_player1
@@ -44,16 +46,16 @@ class Game
   end
 
   def welcome_message
-    "\nWelcome to CONNECT FOUR\nEnter p to play. Enter q to quit.\n"
+    "\nWelcome to CONNECT FOUR\nEnter 'P' to play. Enter 'QUIT' to exit at anytime.\n"
   end
 
   def main_menu_user_input
     choice = user_input
-    if choice == "p"
+    if choice.upcase == "P"
       set_player1
       set_bot
-      "p"
-    elsif choice == "q"
+      "P"
+    elsif choice.upcase == "QUIT"
       abort ":("
     else
       print "\nSorry, please try again.\n"
@@ -63,7 +65,7 @@ class Game
   def main_menu
     print welcome_message
     loop do
-      break if main_menu_user_input == "p"
+      break if main_menu_user_input == "P"
     end
   end
 
@@ -76,13 +78,13 @@ class Game
     loop do
       print "\nTurn #{@turn_count} - #{@board.player_1}, please Select a column:\n"
       @player_1_selection = user_input
-      break if @column_choices.include?(@player_1_selection) == true
+      break if @column_choices.include?(@player_1_selection.upcase) == true
     end
   end
 
   def player_1_turn_sequence
     player_1_selection_loop
-    @player_1_turn.column_select(@player_1_selection)
+    @player_1_turn.column_select(@player_1_selection.upcase)
     @turn_count += 1
     @board.update_layout
     @board.print_layout
@@ -98,6 +100,7 @@ class Game
   
   def game_logic
       player_1_turn_sequence
+      
       return (print "\n#{@board.player_1} wins!\n") if @player_1_turn.connect_four == @board.player_1
       bot_turn_sequence
       return (print "\n#{@board.player_2} wins!\n") if @player_2_turn.connect_four == @board.player_2
@@ -139,7 +142,6 @@ class Game
 end
 
 
-#Need to make column selection not case sensitive - incomplete
 #Need to make bot play again if selected full column - incomplete
 #Need to add draw condition and print
 

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -15,7 +15,7 @@ class Game
   end
 
   def user_input
-    gets.chomp
+    gets.chomp.upcase
   end
 
   def set_player1

--- a/lib/row.rb
+++ b/lib/row.rb
@@ -14,7 +14,7 @@ class Row
         if  @playable == true
             @player = player
             toggle_playable
-        else :invalid_move #evaluate later where best location is for this          
+        else :invalid_move         
         end
     end
 end

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -1,5 +1,5 @@
 class Turn
-  attr_reader :user_selection, :board, :player
+  attr_reader :user_selection, :board, :player, :column_conversion
 
   def initialize(player, board)
     @column_conversion = {'A' => 0, 'B' => 1, 'C' => 2, 'D' => 3, 'E' => 4, 'F' => 5, 'G' => 6}
@@ -9,8 +9,8 @@ class Turn
   end
 
   def column_select (user_input)
-    @user_selection = [@column_conversion[user_input], @player]
-    @board.columns[@user_selection[0]].play_piece(@user_selection[1])
+    @user_selection = [column_conversion[user_input], player]
+    board.columns[user_selection[0]].play_piece(user_selection[1])
   end   
 
   def column_win
@@ -24,8 +24,8 @@ class Turn
         x -= 1
       end
 
-      if player_column.chunk_while{ |a, b| a == b && a != "" }.any?{ |player| player.size == 4}
-        return player_column.max_by{ |player| player_column.count(player)}
+      if player_column.chunk_while{ |a, b| a == b && a != "" }.any?{ |player| player.size >= 4 }
+        return player_column.max_by{ |player| player_column.count(player) }
       end
       
       y += 1
@@ -44,8 +44,8 @@ class Turn
         y += 1
       end
 
-      if player_row.chunk_while{ |a, b| a == b && a != "" }.any?{ |player| player.size == 4}
-        return player_row.max_by{ |player| player_row.count(player)}
+      if player_row.chunk_while{ |a, b| a == b && a != "" }.any?{ |player| player.size >= 4 }
+        return player_row.max_by{ |player| player_row.count(player) }
       end
 
       x -= 1
@@ -69,8 +69,8 @@ class Turn
     
    if check_right.any? { |occupied| occupied.size > 0 }
       right_up.each do |arr|
-        if arr.chunk_while{ |a, b| a == b && a != "" }.any?{ |player_piece| player_piece.size == 4}       
-          return arr.max_by{ |player| arr.count(player)}
+        if arr.chunk_while{ |a, b| a == b && a != "" }.any?{ |player_piece| player_piece.size >= 4 }       
+          return arr.max_by{ |player| arr.count(player) }
         end             
       end    
     end
@@ -93,18 +93,30 @@ class Turn
 
     if check_left.any? { |occupied| occupied.size > 0 }
       left_up.each do |arr|
-        if arr.chunk_while{ |a, b| a == b && a != "" }.any?{ |player_piece| player_piece.size == 4}       
-          return arr.max_by{ |player| arr.count(player)}
+        if arr.chunk_while{ |a, b| a == b && a != "" }.any?{ |player_piece| player_piece.size >= 4 }       
+          return arr.max_by{ |player| arr.count(player) }
         end             
       end    
     end
     :no_win
-  end    
+  end
+
+  
+  def stalemate_check
+    #check top array at end of connect_four if :no_win and if all full then :stalemate
+    arr_top = [board.columns[0].rows[0].player, board.columns[1].rows[0].player, board.columns[2].rows[0].player, board.columns[3].rows[0].player, board.columns[4].rows[0].player, board.columns[5].rows[0].player, board.columns[6].rows[0].player]
+    
+    if arr_top.all?{ |occupied| occupied != "" }
+      :stalemate
+    end
+  end
 
   def connect_four
     win_check = [column_win, row_win, diagonal_rightup, diagonal_leftup]
     if win_check.any?{ |win| win != :no_win }
       return win_check.tally.invert[1]
+    elsif stalemate_check == :stalemate
+      return :stalemate
     end
     :no_win
   end

--- a/spec/column_spec.rb
+++ b/spec/column_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Column do
     #This is the end of valid playing options for this column. Next attempt for a move
     #here should result in an error
     expect(column.count).to eq(0)
-    expect(column.play_piece("Bryan")).to eq(puts "That is an invalid move.")
+    expect(column.play_piece("Bryan")).to eq(:invalid_move)
   end
 
   it '5. adds player name to row when playing piece' do

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -29,27 +29,27 @@ RSpec.describe Turn do
     board = Board.new
     turn = Turn.new('Bryan', board)
 
+    
     expect(board.columns[0].rows[5].playable).to eq(true)
     expect(board.columns[0].rows[5].player).to eq('')
     turn.column_select('A')
 
-    #board.columns[turn.user_selection[0]].play_piece(turn.user_selection[1])
     expect(board.columns[0].rows[5].playable).to eq(false)
     expect(board.columns[0].rows[5].player).to eq('Bryan')
     expect(board.columns[0].rows[4].playable).to eq(true)
 
   end
 
-  xit '4. it accurately toggles which rows are playable' do
+  it '4. it accurately toggles which rows are playable' do
     board = Board.new
     turn = Turn.new('Bryan', board)
 
-    turn.column_select('A')
     expect(board.columns[0].rows[5].playable).to eq(true)
     expect(board.columns[0].rows[5].player).to eq('')
+    
 
     3.times do
-      board.columns[turn.user_selection[0]].play_piece(turn.user_selection[1])
+      turn.column_select('A')
     end
 
     expect(board.columns[0].rows[5].playable).to eq(false)
@@ -63,30 +63,28 @@ RSpec.describe Turn do
 
   end
 
-  xit '5. does not allow an invalid player move' do        
+  it '5. does not allow an invalid player move' do        
     board = Board.new
     turn = Turn.new('Bryan', board)
-    turn.column_select('A')
-
+    
     6.times do
-      board.columns[turn.user_selection[0]].play_piece(turn.user_selection[1])
+      turn.column_select('A')
     end
 
     expect(board.columns[0].rows[0].playable).to eq(false)
     expect(board.columns[0].rows[0].player).to eq('Bryan')
       
     #invalid player move here
-    expect(board.columns[turn.user_selection[0]].play_piece(turn.user_selection[1])).to eq(puts 'That is an invalid move.')
+    expect(turn.column_select('A')).to eq(:invalid_move)
 
   end 
 
-  xit '6. checks first column for vertical win' do
+  it '6. checks first column for vertical win' do
     board = Board.new
     turn = Turn.new('Bryan', board)
 
-    turn.column_select('A')
     4.times do
-      board.columns[turn.user_selection[0]].play_piece(turn.user_selection[1])
+      turn.column_select('A')
     end
 
     expect(turn.column_win).to eq('Bryan')
@@ -94,19 +92,17 @@ RSpec.describe Turn do
 
   end
 
-  xit '7. checks other columns for vertical wins' do
+  it '7. checks other columns for vertical wins' do
     board = Board.new
     turn1 = Turn.new('Bryan', board)
     turn2 = Turn.new('Mostafa', board)
     
-    turn1.column_select('D')    
     2.times do
-      board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
+      turn1.column_select('D') 
     end
-
-    turn2.column_select('D')
+    
     4.times do
-      board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
+      turn2.column_select('D')
     end
     
     expect(turn1.column_win).to eq('Mostafa')
@@ -115,43 +111,33 @@ RSpec.describe Turn do
 
   end
 
-  xit '8. does not give false positives for vertical wins' do
+  it '8. does not give false positives for vertical wins' do
     board = Board.new
     turn1 = Turn.new('Bryan', board)
     turn2 = Turn.new('Mostafa', board)
 
-    turn1.column_select('D')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
-    turn2.column_select('D')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
-    turn1.column_select('D')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
-    turn2.column_select('D')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
-    turn2.column_select('D')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
-    turn2.column_select('D')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
-
+    turn1.column_select('D')    
+    turn2.column_select('D')    
+    turn1.column_select('D')    
+    turn2.column_select('D')  
+    turn2.column_select('D')   
+    turn2.column_select('D')  
+    
     expect(turn1.column_win).to eq(:no_win)
     expect(turn2.column_win).to eq(:no_win)
     expect(turn1.connect_four).to eq(:no_win)
 
   end
 
-  xit '9. checks first row for horizontal win' do
+  it '9. checks first row for horizontal win' do
     board = Board.new
     turn1 = Turn.new('Bryan', board)
     turn2 = Turn.new('Mostafa', board)
 
     turn2.column_select('D')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn2.column_select('C')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn2.column_select('E')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn2.column_select('F')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
   
     expect(turn1.row_win).to eq('Mostafa')
     expect(turn2.row_win).to eq('Mostafa')
@@ -159,40 +145,28 @@ RSpec.describe Turn do
 
   end
 
-  xit '10. checks other rows for horizontal win' do
+  it '10. checks other rows for horizontal win' do
     board = Board.new
     turn1 = Turn.new('Bryan', board)
     turn2 = Turn.new('Mostafa', board)
 
     #row 1
     turn2.column_select('D')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn1.column_select('C')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
     turn2.column_select('E')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn2.column_select('F')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
 
     #row 2
     turn2.column_select('D')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn1.column_select('C')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
     turn2.column_select('E')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn2.column_select('F')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
 
     #row 3 - winning row
     turn1.column_select('D')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
     turn1.column_select('C')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
     turn1.column_select('E')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
     turn1.column_select('F')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
 
     expect(turn1.row_win).to eq('Bryan')
     expect(turn2.row_win).to eq('Bryan')
@@ -200,40 +174,28 @@ RSpec.describe Turn do
 
   end
 
-  xit '11. does not return false positives for horizontal wins' do
+  it '11. does not return false positives for horizontal wins' do
     board = Board.new
     turn1 = Turn.new('Bryan', board)
     turn2 = Turn.new('Mostafa', board)
 
     #row 1
     turn2.column_select('D')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn1.column_select('C')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
     turn2.column_select('E')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn2.column_select('F')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
 
     #row 2
     turn2.column_select('D')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn1.column_select('C')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
     turn2.column_select('E')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn2.column_select('F')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
 
     #row 3 - winning row
     turn1.column_select('D')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
     turn2.column_select('C')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn1.column_select('E')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
     turn1.column_select('F')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
 
     expect(turn1.row_win).to eq(:no_win)
     expect(turn2.row_win).to eq(:no_win)
@@ -241,31 +203,21 @@ RSpec.describe Turn do
 
   end
 
-  xit '12. checks right and up diagonal wins' do
+  it '12. checks right and up diagonal wins' do
     board = Board.new
     turn1 = Turn.new('Bryan', board)
     turn2 = Turn.new('Mostafa', board)
 
     turn1.column_select('C')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
     turn2.column_select('D')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn1.column_select('D')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
     turn2.column_select('E')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn2.column_select('E')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn1.column_select('E')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
     turn2.column_select('F')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn2.column_select('F')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn2.column_select('F')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn1.column_select('F')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
     
     #win condition is in arr4, or right_up[4]    
 
@@ -275,31 +227,21 @@ RSpec.describe Turn do
 
   end
 
-  xit '13. checks left and up diagonal wins' do
+  it '13. checks left and up diagonal wins' do
     board = Board.new
     turn1 = Turn.new('Mostafa', board)
     turn2 = Turn.new('Bryan', board)
 
     turn1.column_select('G')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
     turn2.column_select('F')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn1.column_select('F')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
     turn2.column_select('E')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn2.column_select('E')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn1.column_select('E')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
     turn2.column_select('D')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn2.column_select('D')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn2.column_select('D')
-    board.columns[turn2.user_selection[0]].play_piece(turn2.user_selection[1])
     turn1.column_select('D')
-    board.columns[turn1.user_selection[0]].play_piece(turn1.user_selection[1])
 
     expect(turn1.diagonal_rightup).to eq(:no_win)
     expect(turn1.diagonal_leftup).to eq('Mostafa')
@@ -307,7 +249,7 @@ RSpec.describe Turn do
 
   end
 
-  xit '14. does not confuse empty spaces for players' do
+  it '14. does not confuse empty spaces for players' do
     board = Board.new
     turn1 = Turn.new('Mostafa', board)
     turn2 = Turn.new('Bryan', board)
@@ -317,6 +259,58 @@ RSpec.describe Turn do
     expect(turn1.diagonal_rightup).to eq(:no_win)
     expect(turn1.diagonal_leftup).to eq(:no_win)
     expect(turn1.connect_four).to eq(:no_win)    
+
+  end
+
+  it '15. returns :stalemate if there are no more available plays' do
+    board = Board.new
+    turn1 = Turn.new('Mostafa', board)
+    turn2 = Turn.new('Bryan', board)
+
+    3.times do
+      turn1.column_select('A')
+      turn2.column_select('A')
+
+      turn2.column_select('B')
+      turn1.column_select('B')
+
+      turn2.column_select('C')
+      turn1.column_select('C')
+
+      turn1.column_select('D')
+      turn2.column_select('D')
+
+      turn1.column_select('E')
+      turn2.column_select('E')
+
+      turn2.column_select('F')
+      turn1.column_select('F')
+
+      turn2.column_select('G')
+      turn1.column_select('G')
+    end
+
+    expect(turn1.column_win).to eq(:no_win)
+    expect(turn1.row_win).to eq(:no_win)
+    expect(turn1.diagonal_rightup).to eq(:no_win)
+    expect(turn1.diagonal_leftup).to eq(:no_win)
+    expect(turn1.stalemate_check).to eq(:stalemate)
+    expect(turn1.connect_four).to eq(:stalemate)   
+
+  end
+
+  it '16. checks for wins over four pieces long' do
+    #this test was created to add an additional check due to an unforeseen 
+    #false negatives encountered during later testing 
+    board = Board.new
+    turn = Turn.new('Mostafa', board)
+
+    6.times do
+      turn.column_select('A')
+    end
+
+    expect(turn.column_win).to eq('Mostafa')
+    expect(turn.connect_four).to eq('Mostafa')
 
   end
     


### PR DESCRIPTION
This branch has many small, but critical changes. The magic sauce line of `player_column.chunk_while{ |a, b| a == b && a != "" }.any?{ |player| player.size == 4 }` was found to be giving false negatives when the player won with over four pieces and was changed accordingly. 

Also the `stalemate_check` method was added with corresponding tests. Invalid moves were standardized to return `:invalid_move` as opposed to the symbol/string we had in row/column respectively. 

A few changes were made to game.rb to allow the player to exit the game during the session. Small changes for capitalization to be standardized from player input. 

Tests were remade to match new `column_select` method, and the @ from instance variables were removed from some of the larger methods when the instance variables were only being called and not changed. This was done to improve readability of code. 